### PR TITLE
Remove `min-release-age` from .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,6 +2,3 @@ git-tag-version = false
 
 ignore-scripts = true
 allow-git = root
-
-# Matches 'security:minimumReleaseAgeNpm' Renovate preset
-min-release-age = 3


### PR DESCRIPTION
Breaks Renovate's lock file maintenance when one of the packages is newer.