### PR TITLE
Explicitly persist Git credentials in test CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: true
 
       - name: Generate branch name
         id: ref_name


### PR DESCRIPTION
Silence zizmor alert.